### PR TITLE
fix(standup): delete user's message and add user info in footer

### DIFF
--- a/src/commandHandlers/standup.ts
+++ b/src/commandHandlers/standup.ts
@@ -1,4 +1,4 @@
-import { MessageEmbed } from 'discord.js';
+import { MessageEmbed, Message } from 'discord.js';
 
 /**
  * This command lets the user create a message for the daily standup in the community. For more information on
@@ -6,13 +6,20 @@ import { MessageEmbed } from 'discord.js';
  *
  * {link https://www.atlassian.com/agile/scrum/standups}
  */
-export const command = async (arg: string, embed: MessageEmbed) => {
+export const command = async (arg: string, embed: MessageEmbed, message: Message) => {
+    // Note: The delete operation requires the permission "MANAGE_MESSAGES".
+    // No need to await for the promise since sending the embed message doesn't depend on this message being deleted.
+    if (message.deletable) {
+        message.delete();
+    }
+
     const args = arg.split('||');
     embed
         .setTitle('Standup')
         .setDescription('What I did yesterday and what I will do today')
         .addField('Yesterday', args[0])
         .addField('Today', args[1])
+        .setFooter(message.author.username, message.author.avatarURL() || undefined)
 
     return embed;
 };

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -18,6 +18,5 @@ export const commands = async (message: Message) => {
     const matching = commandList
         .find(({ triggers }) => triggers
             .find((trigger) => trigger === command)) || { command: fallback };
-
-    message.channel.send(await matching.command(args.slice(command.length + 1), embed));
+    message.channel.send(await matching.command(args.slice(command.length + 1), embed, message));
 };


### PR DESCRIPTION
_Note:_ If you try to test this change locally, you'll need to add the **Manage Messages** permission to the bot, or you will get an error. For more info. read [these docs](https://discordjs.guide/popular-topics/permissions-extended.html#missing-permissions)

### Example of the new standup message:
![imagem](https://user-images.githubusercontent.com/18630253/83971574-f6c6a200-a8d3-11ea-81ec-15f7fd1cbabc.png)

Closes: #55