### PR TITLE
Add Gateway Intents to the discord client

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,26 @@ or
 log.fatal('Message', 'Details');
 ```
 
+### [Discord Gateway Intents](https://discordjs.guide/popular-topics/intents.html)
+If you want the bot to receive a **new type of event**, you might need to add the required intent in `client.ts` to receive that event. Have a look at [discord.js docs](https://discord.js.org/#/docs/main/stable/class/Intents?scrollTo=s-FLAGS) for the list of intents.
+
+#### Example adding ban capabilities to moderators:
+1. Add the `GUILD_BANS` intent in `client.ts`:
+```ts
+export const client = new Client({
+    partials: ['MESSAGE', 'CHANNEL', 'REACTION'],
+    ws: { intents: ['GUILDS', 'GUILD_MESSAGES', 'GUILD_MESSAGE_REACTIONS', 'GUILD_BANS', PrivilegedIntents.GUILD_MEMBERS] }
+});
+```
+
+2. Add an event handler function for the events you want in `index.ts`:
+```ts
+client.on('guildBanAdd', guild => guildBanAdd(guild));
+```
+
+_Note: We are using the `GUILD_MEMBERS` **privileged intent** to receive the `guildMemberAdd` event. To know more about Privileged Intents check the [official docs](https://discord.com/developers/docs/topics/gateway#privileged-intents)_.
+
+
 ## Socials
 
 Join our discord community [here](https://discord.gg/jZQs6Wu)

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,3 +1,12 @@
 import { Client } from 'discord.js';
 
-export const client: Client = new Client({ partials: ['MESSAGE', 'CHANNEL', 'REACTION'] });
+// Official docs: https://discord.com/developers/docs/topics/gateway#privileged-intents
+enum PrivilegedIntents {
+    GUILD_PRESENCES = 'GUILD_PRESENCES',
+    GUILD_MEMBERS =  'GUILD_MEMBERS'
+}
+
+export const client = new Client({
+    partials: ['MESSAGE', 'CHANNEL', 'REACTION'],
+    ws: { intents: ['GUILDS', 'GUILD_MESSAGES', 'GUILD_MESSAGE_REACTIONS', PrivilegedIntents.GUILD_MEMBERS] }
+});


### PR DESCRIPTION
> ⚠️ Before merging this change, @eddiejaoude you need to go to Dev Portal and enable the **SERVER MEMBERS INTENT**, because we use one [privileged intent](https://discordjs.guide/popular-topics/intents.html#privileged-intents).

Anyone testing this can check more information [here](https://support.discord.com/hc/en-us/articles/360040720412-Bot-Verification-and-Data-Whitelisting#privileged-intent-whitelisting). I don't think we need to verify the bot for now since **it's not in 100 servers**, so enabling that toggle on the Dev Portal, under the Bot menu, should be enough:
![imagem](https://user-images.githubusercontent.com/18630253/84597601-ed51b280-ae5c-11ea-88b8-885ab4f2b331.png)

Closes: #36 