### PR TITLE
feat(bio): when user sets any bio, give them bio role

### DIFF
--- a/src/commandHandlers/bio.ts
+++ b/src/commandHandlers/bio.ts
@@ -49,6 +49,10 @@ export const command = async (arg: string, embed: MessageEmbed, message: Message
                     [data]: args[1]
                 }
             }, { merge: true });
+
+        const role = message.guild!.roles.cache.find((r) => r.name === config.ROLE.BIO);
+        const member = message.member;
+        await member!.roles.add(role!);
     }
 
     embed

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,7 +8,8 @@ export default {
   BOT_CHANNEL_ID: process.env.DISCORD_BOT_CHANNEL_ID,
   REACTIONS_COUNT: 5,
   ROLE: {
-    HIGH_VALUE: 'high value'
+    HIGH_VALUE: 'high value',
+    BIO: 'bio',
   },
   defaultEmbed: () => {
     return new MessageEmbed()


### PR DESCRIPTION
closes #86 

Users that set any `bio` info, they get a the role `bio` which makes their name blue

<img width="728" alt="Screenshot 2020-07-01 12 03 12" src="https://user-images.githubusercontent.com/624760/86237006-e2a05880-bb92-11ea-9615-65e232a42d4c.png">

<img width="947" alt="Screenshot 2020-07-01 12 03 22" src="https://user-images.githubusercontent.com/624760/86237037-f64bbf00-bb92-11ea-8e69-5144041b363f.png">

