### PR TITLE
fix(timezone): fixed IST timezone #89

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -22,6 +22,6 @@ export default {
     { abbr: 'AEST', zone: 'Australia/Brisbane' },
     { abbr: 'EEST', zone: 'Asia/Beirut' },
     { abbr: 'UTC', zone: 'Europe/London' },
-    { abbr: 'IST', zone: 'Asia/India' },
+    { abbr: 'IST', zone: 'Asia/Kolkata' },
   ]
 };


### PR DESCRIPTION
> Asia/India doesnt exist in momentjs but apparently the same time zone identifier they use is Asia/Kolkata which is IST

<img width="832" alt="Screenshot 2020-07-03 13 28 41" src="https://user-images.githubusercontent.com/624760/86469356-20d37e80-bd31-11ea-987d-10fb8fc9cf3e.png">
