### PR TITLE
feat(roles): add roles command

### DIFF
--- a/src/commandHandlers/guild.service.ts
+++ b/src/commandHandlers/guild.service.ts
@@ -3,7 +3,7 @@ import { Role, Collection } from 'discord.js';
 import { client as discordClient } from '../client';
 import { log } from '../logger';
 
-export async  function getRoles(): Promise<Collection<string, Role>> {
+export async function getRoles(): Promise<Collection<string, Role>> {
     const guildKey = process.env.DISCORD_SERVER_ID;
     if (!guildKey) {
         log.error('ERROR: Couldn\'t get roles list! Missing env. variable DISCORD_SERVER_ID. Please configure that value.');

--- a/src/commandHandlers/guild.service.ts
+++ b/src/commandHandlers/guild.service.ts
@@ -1,0 +1,20 @@
+import { Role, Collection } from 'discord.js';
+
+import { client as discordClient } from '../client';
+import { log } from '../logger';
+
+export async  function getRoles(): Promise<Collection<string, Role>> {
+    const guildKey = process.env.DISCORD_SERVER_ID;
+    if (!guildKey) {
+        log.error('ERROR: Couldn\'t get roles list! Missing env. variable DISCORD_SERVER_ID. Please configure that value.');
+        return new Collection();
+    }
+
+    const guild = discordClient.guilds.cache.get(guildKey);
+    if (!guild) {
+        log.error('ERROR: Couldn\'t get roles list! The guild with the configured DISCORD_SERVER_ID env. variable doesn\'t exist');
+        return new Collection();
+    }
+
+    return guild.roles.cache;
+}

--- a/src/commandHandlers/index.ts
+++ b/src/commandHandlers/index.ts
@@ -3,7 +3,8 @@ import * as codeOfConduct from './codeOfConduct';
 import * as help from './help';
 import * as standup from './standup';
 import * as stats from './stats';
+import * as roles from './roles';
 
-export default [bio, codeOfConduct, help, standup, stats];
+export default [bio, codeOfConduct, help, roles, standup, stats];
 
 export { fallback } from './fallback';

--- a/src/commandHandlers/roles.ts
+++ b/src/commandHandlers/roles.ts
@@ -1,0 +1,26 @@
+import { MessageEmbed } from 'discord.js';
+
+import { getRoles } from './guild.service';
+
+/**
+ * This command lists the available roles on the discord server
+ */
+export const command = async (arg: string, embed: MessageEmbed) => {
+    const roles = await getRoles();
+    const rolesList = roles
+        .filter(r => !r.name.includes('everyone')) // Filter the default role everyone has access to
+        .map(role => `\n• ${role.toString()}`);
+
+    embed
+        .setTitle('Available Roles')
+        .setDescription(`Here is the list of roles on this server. You can assign any role to yourself, except the ones for admins or given to you via a condition!
+        ${rolesList}`);
+
+    return embed;
+};
+
+export const description = 'Server roles';
+
+export const triggers = ['roles'];
+
+export const usage = triggers[0];


### PR DESCRIPTION
Issue: #74

**Questions**
- Where will we store the role description?
- Do we implement a different command to assign roles to users (`$iam <role>`) on this PR?

_Note_: I was thinking of renaming `guild.service` to `roles.service` but I think our idea of a **service** module could be more geared for the **Domain Model**, and not a feature. So this file would have more functions related to `Guilds` (basically the `discordClient.guilds` field from the discord.js API)