### PR TITLE
feat(timezone): utc has an alias of uk

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -27,7 +27,7 @@ export default {
     { abbr: 'PDT', zone: 'America/Los_Angeles' },
     { abbr: 'AEST', zone: 'Australia/Brisbane' },
     { abbr: 'EEST', zone: 'Asia/Beirut' },
-    { abbr: 'UTC', zone: 'Europe/London' },
+    { abbr: 'UTC', zone: 'Europe/London' }, { abbr: 'UK', zone: 'Europe/London' },
     { abbr: 'IST', zone: 'Asia/Kolkata' },
   ]
 };

--- a/src/timezone.ts
+++ b/src/timezone.ts
@@ -17,7 +17,7 @@ export const timezone = async (message: Message) => {
         return;
     }
 
-    const match = message.content.match(/([\d]{1,2})([:\d]{3})?[\s]?(pm|am|AM|PM)?\b[\s]([a-zA-Z]{3})?\b/);
+    const match = message.content.match(/([\d]{1,2})([:\d]{3})?[\s]?(pm|am|AM|PM)?\b[\s]([a-zA-Z]{2,3})?\b/);
 
     if (match) {
         const [mentioned, hour, minutes, dayNight, zone] = match;


### PR DESCRIPTION
closes #106 

`UK` is an alias for `UTC` (because I always write UK 🤦 ) as spotted by @alrifay - great spot 👍 