### PR TITLE
refactor: add trace logs to open source reminder

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -32,4 +32,5 @@ export const log = {
     warn: (message: string, details?: string) => discordLog('warn', message, details),
     error: (message: string, details?: string) => discordLog('error', message, details),
     fatal: (message: string, details?: string) => discordLog('fatal', message, details),
+    trace: (message: string, details?: string) => discordLog('trace', message, details),
 }

--- a/src/opensourceReminder.job.ts
+++ b/src/opensourceReminder.job.ts
@@ -4,6 +4,7 @@ import { getConfiguredGuild } from './commandHandlers/guild.service';
 import { db } from './firebase';
 import { UserSubscriptions } from './config';
 import { log } from './logger';
+import { Collection, GuildMember } from 'discord.js';
 
 export function scheduleOpenSourceReminder() {
     scheduleJob(config.OPENSOURCE_JOB_CRON_TIME, reminderCallback, 'opensource-reminder');
@@ -17,18 +18,7 @@ async function reminderCallback() {
     // TODO: use the GitHub API to check if the user has already contributed on this day.
     // TODO: if he has, then send a rewarding positive message instead of a reminder.
 
-    // Get the list of users that are subscribed to the open source subscription
-    const querySnapshot = await db.collection('usersSubscriptions').get();
-    const userNamesToSendMessage = querySnapshot
-        .docs
-        .filter(doc => {
-            const userSubscription = doc.data() as UserSubscriptionDb;
-            return userSubscription.subscriptions.includes(UserSubscriptions.OPEN_SOURCE);
-        })
-        .map(doc => (doc.data() as UserSubscriptionDb).username);
-    const guild = getConfiguredGuild();
-    const allMembers = await guild!.members.fetch();
-    const subscribedUsers = allMembers.filter(member => userNamesToSendMessage.includes(member.user.username));
+    const subscribedUsers = await getOpenSourceSubscribedUsers();
 
     // Send the messages in parallel to subscribed users
     log.info(`Starting to send open source reminder messages to ${subscribedUsers.size} subscribed users`);
@@ -49,6 +39,32 @@ async function reminderCallback() {
     })
     await Promise.all(promises);
     log.info('Succesfully sent open source reminder messages');
+}
+
+async function getOpenSourceSubscribedUsers(): Promise<Collection<string, GuildMember>> {
+    log.info(`Getting open source subscribed users`);
+
+    log.trace(`Getting querySnapshot`);
+    const querySnapshot = await db.collection('usersSubscriptions').get();
+    log.trace(`Got querySnapshot`);
+
+    const userNamesToSendMessage = querySnapshot
+        .docs
+        .filter(doc => {
+            const userSubscription = doc.data() as UserSubscriptionDb;
+            return userSubscription.subscriptions.includes(UserSubscriptions.OPEN_SOURCE);
+        })
+        .map(doc => (doc.data() as UserSubscriptionDb).username);
+    log.trace(`Got userNamesToSendMessage: ${userNamesToSendMessage}`);
+
+    const guild = getConfiguredGuild();
+    log.trace(`Getting all members from guild`);
+    const allMembers = await guild!.members.fetch();
+    log.trace(`Got all members from guild`);
+    const subscribedUsers = allMembers.filter(member => userNamesToSendMessage.includes(member.user.username));
+
+    log.info(`Got open source subscribed users`);
+    return subscribedUsers;
 }
 
 // This type represents the model/schema of a document in the "usersSubscriptions" collection

--- a/src/scheduler.service.ts
+++ b/src/scheduler.service.ts
@@ -19,6 +19,7 @@ export function scheduleJob(timeRule: string | number | Date, job: () => Promise
       log.info(`Finished the job${jobName}`);
     } catch(e) {
       log.error('An error occurred:', e.message);
+      log.trace(e.stack);
       throw e;
     }
   });


### PR DESCRIPTION
Refactored the code block that gets the subscribedUsers into its own function, instead of having a comment.

These trace logs and the stack trace (in logger.ts) should give us more information where the error of this issue is coming from (Firestore or Discord.js).

@eddiejaoude do you think we could deploy this change to EddieBotDev and add `LOG_LEVEL=trace` when running the bot? I couldn't reproduce the error locally, so I'm not sure what is causing it. This PR wouldn't close the issue, just help us debug it.

Issue: #221