### PR TITLE
feat(tips): load files from config

### DIFF
--- a/src/commandHandlers/tips/opensource.service.ts
+++ b/src/commandHandlers/tips/opensource.service.ts
@@ -3,17 +3,9 @@ import * as path from 'path';
 import config from '../../config';
 import { log } from '../../logger';
 
-export async function getOpenSourceTips(): Promise<string> {
-    return await readMarkdown('openSourceTips.md');
-}
-
-export async function getOpenSourceResources(): Promise<string> {
-    return await readMarkdown('openSourceResources.md');
-}
-
-async function readMarkdown(fileName: string) {
+export async function readMarkdown(fileName: string) {
     try {
-        const filePath = path.resolve(path.join(config.TIPS_DIRECTORY, `/${fileName}`));
+        const filePath = path.resolve(path.join(config.TIPS.directory, fileName));
         return (await fs.readFile(filePath)).toString();
     } catch(e) {
         log.error(`ERROR: Could not read file: ${fileName} - ${e.message}`);

--- a/src/commandHandlers/tips/opensource.ts
+++ b/src/commandHandlers/tips/opensource.ts
@@ -1,18 +1,22 @@
 import { MessageEmbed } from 'discord.js';
 
-import { getOpenSourceResources, getOpenSourceTips } from './opensource.service';
+import config from '../../config';
+import { readMarkdown } from './opensource.service';
 
 /**
  * Set the given embed message with a curated list of tips and resources that help members of the community to
  * contribute to open-source software (OSS).
  */
 export const createTip = async (embed: MessageEmbed) => {
-    const tips = await getOpenSourceTips();
-    const resources = await getOpenSourceResources();
+
+    const tips = await Promise.all(config.TIPS.tips.map((file) => readMarkdown(file)));
+    const resources = await Promise.all(config.TIPS.resources.map((file) => readMarkdown(file)));
+
+    tips.forEach((tip) => embed.addField('Tips :bulb:', tip));
+    resources.forEach((resource) => embed.addField('Links and Resources :link:', resource));
+
     embed
         .setTitle('Open source Tips and Resources')
-        .addField('Tips :bulb:', tips)
-        .addField('Links and Resources :link:', resources)
         .addField('Help us with this list :heart:', 'If you want to contribute to this list, feel free to [open an issue](https://github.com/EddieJaoudeCommunity/EddieBot/issues). Label it with "command: opensource" so we can easily find your tips and links :slight_smile:');
 
     return embed;

--- a/src/commandHandlers/tips/tips.ts
+++ b/src/commandHandlers/tips/tips.ts
@@ -21,6 +21,7 @@ export const command = async (arg: string, embed: MessageEmbed) => {
 
     switch (subject) {
         case 'opensource':
+        case 'github':
             return createTip(embed);
         default:
             return embed

--- a/src/config.ts
+++ b/src/config.ts
@@ -35,7 +35,11 @@ export default {
     { abbr: 'IST', zone: 'Asia/Kolkata' },
   ],
   OPENSOURCE_JOB_CRON_TIME: process.env.OPENSOURCE_JOB_CRON_TIME || '0 14 * * *', // Default time is everyday at 2pm
-  TIPS_DIRECTORY: './tips',
+  TIPS: {
+    directory: './tips',
+    tips: [ 'openSourceTips.md', 'githubTips.md' ],
+    resources: [ 'openSourceResources.md' ],
+  },
   WORDS: {
     prepend: [
       'hello', 'hey', 'hi', 'yo', 'hiya', 'whatsup', 'greetings',


### PR DESCRIPTION
closes #253 

This could probably be split up into more arguments later on, for example

- `^tips opensource`
- `^tips github`

<img width="917" alt="Screenshot 2020-09-22 at 13 18 16" src="https://user-images.githubusercontent.com/624760/93880943-2314fb80-fcd6-11ea-891a-47a65f0718f1.png">
