### PR TITLE
feat: similar commands

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2762,6 +2762,11 @@
       "resolved": "https://registry.npmjs.org/sorted-array-functions/-/sorted-array-functions-1.2.0.tgz",
       "integrity": "sha512-sWpjPhIZJtqO77GN+LD8dDsDKcWZ9GCOJNqKzi1tvtjGIzwfoyuRH8S0psunmc6Z5P+qfDqztSbwYR5X/e1UTg=="
     },
+    "soundex-code": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/soundex-code/-/soundex-code-1.0.5.tgz",
+      "integrity": "sha512-rLU1C3Qc3ECIfmG6mU272VnIzd+2UfJvbmpnS1jt11Kiw5F3kfMARPQksh5aK355hWfgqlhEKTnnLfnl5eJaYg=="
+    },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "moment-timezone": "^0.5.31",
     "node-schedule": "^1.3.2",
     "pino": "^6.3.2",
-    "pino-pretty": "^4.0.0"
+    "pino-pretty": "^4.0.0",
+    "soundex-code": "^1.0.5"
   },
   "devDependencies": {
     "@types/node": "^13.11.1",

--- a/src/commandHandlers/fallback.ts
+++ b/src/commandHandlers/fallback.ts
@@ -1,28 +1,13 @@
 import { MessageEmbed } from 'discord.js';
-// @ts-ignore
-import * as soundex from 'soundex-code';
 
 import config from '../config';
-import commandList from './index';
+import { suggestSimilarCommands } from '../suggestSimilarCommands';
 
 const { COMMAND_PREFIX } = config;
 
 export const fallback = async (arg: string, embed: MessageEmbed) => {
   const command = arg;
-
-  const maxLength = 2;
-  const map = new Map();
-  commandList
-      .forEach((commandItem) => map.set(commandItem, soundex(commandItem.triggers[0], maxLength)));
-
-  const reverseMap = new Map();
-  for (const [key, value] of map.entries()) {
-      const previous = reverseMap.get(value) || [];
-      previous.push(key);
-      reverseMap.set(value, previous);
-  }
-
-  const similarCommands = reverseMap.get(soundex(command, maxLength));
+  const similarCommands = suggestSimilarCommands(command);
 
   embed
       .setTitle('ERROR: ooops...command not found');
@@ -32,8 +17,7 @@ export const fallback = async (arg: string, embed: MessageEmbed) => {
           .setDescription('Here is a list of similar commands');
 
       similarCommands
-          // @ts-ignore
-          .forEach((commandItem) => embed
+          .forEach((commandItem: {command: (arg: string, embed: MessageEmbed) => Promise<MessageEmbed>, description: string, triggers: Array<string>, usage: string}) => embed
               .addField(`${COMMAND_PREFIX}${commandItem.triggers[0]}`, `${commandItem.description}\nUsage: ${COMMAND_PREFIX}${commandItem.usage}`, false));
   } else {
       embed

--- a/src/commandHandlers/fallback.ts
+++ b/src/commandHandlers/fallback.ts
@@ -1,5 +1,5 @@
 import { MessageEmbed } from 'discord.js';
-//@ts-ignore
+// @ts-ignore
 import * as soundex from 'soundex-code';
 
 import config from '../config';
@@ -32,7 +32,7 @@ export const fallback = async (arg: string, embed: MessageEmbed) => {
           .setDescription('Here is a list of similar commands');
 
       similarCommands
-          //@ts-ignore
+          // @ts-ignore
           .forEach((commandItem) => embed
               .addField(`${COMMAND_PREFIX}${commandItem.triggers[0]}`, `${commandItem.description}\nUsage: ${COMMAND_PREFIX}${commandItem.usage}`, false));
   } else {

--- a/src/commandHandlers/fallback.ts
+++ b/src/commandHandlers/fallback.ts
@@ -3,6 +3,8 @@ import { MessageEmbed } from 'discord.js';
 import config from '../config';
 import { suggestSimilarCommands } from '../suggestSimilarCommands';
 
+import { CommandHandler } from './index';
+
 const { COMMAND_PREFIX } = config;
 
 export const fallback = async (arg: string, embed: MessageEmbed) => {
@@ -17,7 +19,7 @@ export const fallback = async (arg: string, embed: MessageEmbed) => {
           .setDescription('Here is a list of similar commands');
 
       similarCommands
-          .forEach((commandItem: {command: (arg: string, embed: MessageEmbed) => Promise<MessageEmbed>, description: string, triggers: string[], usage: string}) => embed
+          .forEach((commandItem: CommandHandler) => embed
               .addField(`${COMMAND_PREFIX}${commandItem.triggers[0]}`, `${commandItem.description}\nUsage: ${COMMAND_PREFIX}${commandItem.usage}`, false));
   } else {
       embed

--- a/src/commandHandlers/fallback.ts
+++ b/src/commandHandlers/fallback.ts
@@ -17,7 +17,7 @@ export const fallback = async (arg: string, embed: MessageEmbed) => {
           .setDescription('Here is a list of similar commands');
 
       similarCommands
-          .forEach((commandItem: {command: (arg: string, embed: MessageEmbed) => Promise<MessageEmbed>, description: string, triggers: Array<string>, usage: string}) => embed
+          .forEach((commandItem: {command: (arg: string, embed: MessageEmbed) => Promise<MessageEmbed>, description: string, triggers: string[], usage: string}) => embed
               .addField(`${COMMAND_PREFIX}${commandItem.triggers[0]}`, `${commandItem.description}\nUsage: ${COMMAND_PREFIX}${commandItem.usage}`, false));
   } else {
       embed

--- a/src/commandHandlers/fallback.ts
+++ b/src/commandHandlers/fallback.ts
@@ -1,11 +1,44 @@
 import { MessageEmbed } from 'discord.js';
+//@ts-ignore
+import * as soundex from 'soundex-code';
 
 import config from '../config';
+import commandList from './index';
 
 const { COMMAND_PREFIX } = config;
 
 export const fallback = async (arg: string, embed: MessageEmbed) => {
-  return embed
-    .setTitle('ERROR: ooops...command not found')
-    .setDescription(`Try using the ${COMMAND_PREFIX}help command.`);
+  const command = arg;
+
+  const maxLength = 2;
+  const map = new Map();
+  commandList
+      .forEach((commandItem) => map.set(commandItem, soundex(commandItem.triggers[0], maxLength)));
+
+  const reverseMap = new Map();
+  for (const [key, value] of map.entries()) {
+      const previous = reverseMap.get(value) || [];
+      previous.push(key);
+      reverseMap.set(value, previous);
+  }
+
+  const similarCommands = reverseMap.get(soundex(command, maxLength));
+
+  embed
+      .setTitle('ERROR: ooops...command not found');
+
+  if (similarCommands && similarCommands.length) {
+      embed
+          .setDescription('Here is a list of similar commands');
+
+      similarCommands
+          //@ts-ignore
+          .forEach((commandItem) => embed
+              .addField(`${COMMAND_PREFIX}${commandItem.triggers[0]}`, `${commandItem.description}\nUsage: ${COMMAND_PREFIX}${commandItem.usage}`, false));
+  } else {
+      embed
+          .setDescription(`Try using the ${COMMAND_PREFIX}help command.`);
+  }
+
+  return embed;
 };

--- a/src/commandHandlers/index.ts
+++ b/src/commandHandlers/index.ts
@@ -9,6 +9,15 @@ import * as stats from './stats';
 import * as tips from './tips/tips';
 import * as support from './support';
 
+import { MessageEmbed, Message } from 'discord.js';
+
 export default [bio, codeOfConduct, help, iam, reminder, roles, standup, stats, tips, support];
 
 export { fallback } from './fallback';
+
+export interface CommandHandler {
+    command: (arg: string, embed: MessageEmbed, message: Message) => Promise<MessageEmbed>
+    description: string
+    triggers: string[]
+    usage: string
+}

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -18,5 +18,10 @@ export const commands = async (message: Message) => {
     const matching = commandList
         .find(({ triggers }) => triggers
             .find((trigger) => trigger === command)) || { command: fallback };
-    message.channel.send(await matching.command(args.slice(command.length + 1), embed, message));
+
+    if (matching.command === fallback) {
+        message.channel.send(await matching.command(command, embed, message));
+    } else {
+        message.channel.send(await matching.command(args.slice(command.length + 1), embed, message));
+    }
 };

--- a/src/suggestSimilarCommands.ts
+++ b/src/suggestSimilarCommands.ts
@@ -2,19 +2,28 @@ import commandList from './commandHandlers';
 
 // @ts-ignore
 import * as soundex from 'soundex-code';
+/**
+ * function soundex(value: string, maxLength?: number): string
+ * returns a hash string of maxLength size
+ * of the string value passed to it, s.t.
+ * similar values result in equal hashes
+ */
 
-const maxLength = 2;
-const map = new Map();
+// this map contains the soundex value for each command
+const commandToSoundexMap = new Map();
+const maxLength = 2; // stores the length of hashes
 commandList
-  .forEach((commandItem) => map.set(commandItem, soundex(commandItem.triggers[0], maxLength)));
+  .forEach((commandItem) => commandToSoundexMap.set(commandItem, soundex(commandItem.triggers[0], maxLength)));
 
-const reverseMap = new Map();
-for (const [key, value] of map.entries()) {
-  const previous = reverseMap.get(value) || [];
-  previous.push(key);
-  reverseMap.set(value, previous);
+// this map contains the list of commands for a given soundex key
+const soundexToSimilarCommandsListMap = new Map();
+for (const [key, value] of commandToSoundexMap.entries()) {
+  const previousSimilarCommandsList = soundexToSimilarCommandsListMap.get(value) || [];
+  previousSimilarCommandsList.push(key);
+  soundexToSimilarCommandsListMap.set(value, previousSimilarCommandsList);
 }
 
+// returns a list of similar commands
 export const suggestSimilarCommands = (command: string) => {
-  return reverseMap.get(soundex(command, maxLength));
+  return soundexToSimilarCommandsListMap.get(soundex(command, maxLength));
 };

--- a/src/suggestSimilarCommands.ts
+++ b/src/suggestSimilarCommands.ts
@@ -1,4 +1,4 @@
-import commandList from './commandHandlers';
+import commandList, { CommandHandler } from './commandHandlers';
 
 // @ts-ignore
 import * as soundex from 'soundex-code';
@@ -10,13 +10,13 @@ import * as soundex from 'soundex-code';
  */
 
 // this map contains the soundex value for each command
-const commandToSoundexMap = new Map();
+const commandToSoundexMap = new Map<CommandHandler, string>();
 const maxLength = 2; // stores the length of hashes
 commandList
   .forEach((commandItem) => commandToSoundexMap.set(commandItem, soundex(commandItem.triggers[0], maxLength)));
 
 // this map contains the list of commands for a given soundex key
-const soundexToSimilarCommandsListMap = new Map();
+const soundexToSimilarCommandsListMap = new Map<string, CommandHandler[]>();
 for (const [key, value] of commandToSoundexMap.entries()) {
   const previousSimilarCommandsList = soundexToSimilarCommandsListMap.get(value) || [];
   previousSimilarCommandsList.push(key);

--- a/src/suggestSimilarCommands.ts
+++ b/src/suggestSimilarCommands.ts
@@ -1,0 +1,20 @@
+import commandList from './commandHandlers';
+
+// @ts-ignore
+import * as soundex from 'soundex-code';
+
+const maxLength = 2;
+const map = new Map();
+commandList
+  .forEach((commandItem) => map.set(commandItem, soundex(commandItem.triggers[0], maxLength)));
+
+const reverseMap = new Map();
+for (const [key, value] of map.entries()) {
+  const previous = reverseMap.get(value) || [];
+  previous.push(key);
+  reverseMap.set(value, previous);
+}
+
+export const suggestSimilarCommands = (command: string) => {
+  return reverseMap.get(soundex(command, maxLength));
+};


### PR DESCRIPTION
# Similar Commands Suggestion

closes #245

## Tasks

* [x] add dependency `soundex-code`
* [x] display similar commands
* [x] generate the initial map(`reverseMap`) only once
* [x] add comments and better names in `suggestSimilarCommands.ts` as suggested below
* [x] add `CommandHandler` interface

## Demo

* ### No similar commands

    ![lol](https://user-images.githubusercontent.com/42526976/95016361-2ca44900-0670-11eb-82c8-901c5f24c2a8.png)

* ### Single similar command

    ![hlp](https://user-images.githubusercontent.com/42526976/95016402-6d03c700-0670-11eb-94c3-8418bcbfe463.png)

* ### Multiple similar commands

    ![sta](https://user-images.githubusercontent.com/42526976/95016416-77be5c00-0670-11eb-9683-f26d44548510.png)