### PR TITLE
refactor: changed interface of commandHandler

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,10 +162,11 @@ To **create a new command**, follow these steps:
    - `command` - the function that executes the command. The **signature** of this function is the following:
 
    ```ts
-   (arg: string, embed: MessageEmbed, message: Message): Promise<MessageEmbed>
+   (arg: [string, string], embed: MessageEmbed, message: Message): Promise<MessageEmbed>
    ```
 
    The **arg** parameter contains the arguments given to the command in a string.
+   The **arg** parameter is a tuple of two `string`s where, `arg[0]` is the command name and `arg[1]` is the string of command arguments.
    The **embed** parameter is a [MessageEmbed](https://discord.js.org/#/docs/main/stable/class/MessageEmbed) instance, and it represents the message that is returned by the bot, in response to the user. **The command should return this parameter or a new instance** with an appropriate message to the user.
    The **message** parameter is a [Message](https://discord.js.org/#/docs/main/stable/class/Message) instance that represents the message inputted by the user to execute a given command.
 

--- a/src/commandHandlers/bio.ts
+++ b/src/commandHandlers/bio.ts
@@ -11,11 +11,11 @@ import { log } from '../logger';
  * This command lets the user set their personal data if others want to follow them on other social platforms
  */
 export const command = async (
-  arg: string,
+  arg: [string, string],
   embed: MessageEmbed,
   message: Message
 ) => {
-  const [first, ...rest] = arg.split('||');
+  const [first, ...rest] = arg[1].split('||');
   const content = rest.join('||');
   const mention = message.mentions.users.first();
   const field = first.toLowerCase().trim();

--- a/src/commandHandlers/codeOfConduct.ts
+++ b/src/commandHandlers/codeOfConduct.ts
@@ -1,6 +1,6 @@
 import { MessageEmbed } from 'discord.js';
 
-export const command = async (arg: string, embed: MessageEmbed) => {
+export const command = async (arg: [string, string], embed: MessageEmbed) => {
   return embed
     .setTitle('Code of Conduct (CoC) - Contributor Covenant Code of Conduct')
     .setDescription(

--- a/src/commandHandlers/fallback.ts
+++ b/src/commandHandlers/fallback.ts
@@ -7,8 +7,8 @@ import { CommandHandler } from './index';
 
 const { COMMAND_PREFIX } = config;
 
-export const fallback = async (arg: string, embed: MessageEmbed) => {
-  const command = arg;
+export const fallback = async (arg: [string, string], embed: MessageEmbed) => {
+  const command = arg[0];
   const similarCommands = suggestSimilarCommands(command);
 
   embed.setTitle('ERROR: ooops...command not found');

--- a/src/commandHandlers/help.ts
+++ b/src/commandHandlers/help.ts
@@ -5,7 +5,7 @@ import commandList from './index';
 
 const { COMMAND_PREFIX } = config;
 
-export const command = async (arg: string, embed: MessageEmbed) => {
+export const command = async (arg: [string, string], embed: MessageEmbed) => {
   embed.setTitle('Help commands').setDescription('Lists the command available');
 
   commandList.forEach((commandItem) =>

--- a/src/commandHandlers/iam.ts
+++ b/src/commandHandlers/iam.ts
@@ -11,11 +11,11 @@ import { log } from '../logger';
  * self-assigned.
  */
 export const command = async (
-  arg: string,
+  arg: [string, string],
   embed: MessageEmbed,
   message: Message
 ) => {
-  const args = arg.toLowerCase().split(',');
+  const args = arg[1].toLowerCase().split(',');
   // Check if the user provided the role argument
   if (!args) {
     return buildErrorEmbed('Missing arguments');

--- a/src/commandHandlers/index.ts
+++ b/src/commandHandlers/index.ts
@@ -30,7 +30,7 @@ export { fallback } from './fallback';
 
 export interface CommandHandler {
   command: (
-    arg: string,
+    arg: [string, string],
     embed: MessageEmbed,
     message: Message
   ) => Promise<MessageEmbed>;

--- a/src/commandHandlers/issue.ts
+++ b/src/commandHandlers/issue.ts
@@ -25,7 +25,7 @@ const req = async (q: string): Promise<any[]> => {
  * This command returns a URL for the user to create an issue in the specified github repository
  */
 export const command = async (
-  arg: string,
+  arg: [string, string],
   embed: MessageEmbed,
   message: Message
 ) => {
@@ -64,8 +64,8 @@ export const command = async (
     }
     let url = `${item.html_url}/issues/new`;
 
-    if (arg) {
-      url += `?title=${encodeURI(arg)}`;
+    if (arg[1]) {
+      url += `?title=${encodeURI(arg[1])}`;
     }
     return embed
       .setAuthor(item.owner.login, item.owner.avatar_url, item.owner.html_url)

--- a/src/commandHandlers/reminder.ts
+++ b/src/commandHandlers/reminder.ts
@@ -10,11 +10,11 @@ const CLOCK_EMOJI = ':alarm_clock:';
  * and time they want to receive it.
  */
 export const command = async (
-  arg: string,
+  arg: [string, string],
   embed: MessageEmbed,
   message: Message
 ) => {
-  const [dateString, reminderMessage] = arg.split(ARG_SEPARATOR);
+  const [dateString, reminderMessage] = arg[1].split(ARG_SEPARATOR);
 
   if (!reminderMessage || !dateString) {
     return buildErrorMessage('Missing arguments');

--- a/src/commandHandlers/roles.ts
+++ b/src/commandHandlers/roles.ts
@@ -6,7 +6,7 @@ import config from '../config';
 /**
  * This command lists the available roles on the discord server
  */
-export const command = async (arg: string, embed: MessageEmbed) => {
+export const command = async (arg: [string, string], embed: MessageEmbed) => {
   const roles = await getRoles();
   const rolesList = roles
     .filter((r) => !r.name.includes('everyone')) // Filter the default role everyone has access to

--- a/src/commandHandlers/standup.ts
+++ b/src/commandHandlers/standup.ts
@@ -7,7 +7,7 @@ import { MessageEmbed, Message } from 'discord.js';
  * {link https://www.atlassian.com/agile/scrum/standups}
  */
 export const command = async (
-  arg: string,
+  arg: [string, string],
   embed: MessageEmbed,
   message: Message
 ) => {
@@ -17,7 +17,7 @@ export const command = async (
     message.delete();
   }
 
-  const args = arg.split('||');
+  const args = arg[1].split('||');
 
   if (!args[0] || !args[1]) {
     embed

--- a/src/commandHandlers/stats.ts
+++ b/src/commandHandlers/stats.ts
@@ -2,7 +2,7 @@ import { MessageEmbed } from 'discord.js';
 
 import { statsService } from './stats.service';
 
-export const command = async (arg: string, embed: MessageEmbed) => {
+export const command = async (arg: [string, string], embed: MessageEmbed) => {
   const memberCount = await statsService.getServerMemberCount();
   const totalMessages = await statsService.getServerTotalMessages();
   embed

--- a/src/commandHandlers/support.ts
+++ b/src/commandHandlers/support.ts
@@ -1,7 +1,7 @@
 import { MessageEmbed, Message } from 'discord.js';
 
 export const command = async (
-  arg: string,
+  arg: [string, string],
   embed: MessageEmbed,
   message: Message
 ) => {

--- a/src/commandHandlers/tips/tips.ts
+++ b/src/commandHandlers/tips/tips.ts
@@ -8,8 +8,8 @@ const AVAILABLE_SUBJECTS = ['opensource'];
  * This command receives an argument that specifies the subject the user wants advice on, and then returns an embed
  * message with the tips and resources on that subject.
  */
-export const command = async (arg: string, embed: MessageEmbed) => {
-  const [subject] = arg.split('||');
+export const command = async (arg: [string, string], embed: MessageEmbed) => {
+  const [subject] = arg[1].split('||');
 
   if (!subject) {
     return embed

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -27,12 +27,8 @@ export const commands = async (message: Message) => {
     triggers.find((trigger) => trigger === command)
   ) || { command: fallback };
 
-  if (matching.command === fallback) {
-    message.channel.send(await matching.command(command, embed, message));
-  } else {
-    message.channel.send(
-      await matching.command(args.slice(command.length + 1), embed, message)
-    );
-    cooldown.setCool(message.author.id);
-  }
+  message.channel.send(
+    await matching.command([command, args.slice(command.length + 1)], embed, message)
+  );
+  cooldown.setCool(message.author.id);
 };

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -28,7 +28,11 @@ export const commands = async (message: Message) => {
   ) || { command: fallback };
 
   message.channel.send(
-    await matching.command([command, args.slice(command.length + 1)], embed, message)
+    await matching.command(
+      [command, args.slice(command.length + 1)],
+      embed,
+      message
+    )
   );
   cooldown.setCool(message.author.id);
 };


### PR DESCRIPTION
fixes #291
@BOLT04 I tried to do it a little differently:
```diff
- arg: string // Here, arg was represented the string of arguments passed to each command.
+ arg: [string, string] // Here, arg[0] represents the command name and arg[1] represents the string of arguments passed to the command.
```
because this fits in a little easily without having to execute the `args.slice(command.length + 1)` in every `commandHandler`.
* [x] change interface of `commandHandler`
* [x] change related info in readme
* [ ] fix `cooldown` issue