### PR TITLE
Add missing roles

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -153,6 +153,9 @@ export const selfAssignableRoles = [
   'flutter',
   'typescript',
   'opensource',
+  'node',
+  'kotlin',
+  'svelte',
 ];
 
 export const issueRequestConfig: AxiosRequestConfig = {


### PR DESCRIPTION
Signed-off-by: nhcarrigan <nhcarrigan@gmail.com>

While exploring the role-adding feature in the Discord server, I discovered that I couldn't add the `node` role to myself. A bit of digging suggests that it was missing from the `selfAssignableRoles` config, so I've added it in (as well as the two other tech-based roles I saw were missing).