### PR TITLE
fix: adding 'host' to ignore list

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -78,6 +78,7 @@ export default {
       'daft',
       'master',
       'clearly',
+      'moaning',
     ],
   },
 };

--- a/src/config.ts
+++ b/src/config.ts
@@ -79,6 +79,7 @@ export default {
       'master',
       'clearly',
       'moaning',
+      'host',
     ],
   },
 };


### PR DESCRIPTION
closes #319 
- [x] added `host` to ignore list