### PR TITLE
fix(bot): Added 'of course' to the ignore list

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -100,6 +100,7 @@ export default {
       'husband',
       'obviously',
       'simple',
+      'of course'
     ],
   },
 };


### PR DESCRIPTION
Brief: Added the word of course to the ignore list as mentioned in #333 
I'd appreciate any suggestions or changes.