### PR TITLE
fix(bot) : Added 'pop' to ignore list

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -92,6 +92,7 @@ export default {
       'obviously',
       'simple',
       'of course',
+      'pop',
     ],
   },
 };


### PR DESCRIPTION
Added the word 'pop' to the EddieBot ignore list as per issue #349