### PR TITLE
fix/alex-nobinary

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -78,6 +78,7 @@ export default {
   },
   ALEX: {
     profanitySureness: 2,
+    noBinary: true,
     allow: [
       'just',
       'brother-sister',


### PR DESCRIPTION
Signed-off-by: nhcarrigan <nhcarrigan@gmail.com>

Adding this config option should cause alex to flag `he or she`. Discussion in the discord server brought to light that allowing `he or she` enforces the gender binary and thus excludes our nonbinary members. 