### PR TITLE
fix: remove all-contributors badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,7 @@
 # EddieBot
 
-![Production workflow](https://github.com/EddieJaoudeCommunity/EddieBot/workflows/production/badge.svg)
+
 ![Develop workflow](https://github.com/EddieJaoudeCommunity/EddieBot/workflows/develop/badge.svg)
-
-<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-
-[![All Contributors](https://img.shields.io/badge/all_contributors-11-orange.svg?style=flat-square)](#contributors-)
-
-<!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 Discord bot for Eddie Jaoude's Discord server
 


### PR DESCRIPTION
regarding #358 and [Support #469](https://github.com/EddieJaoudeCommunity/support/issues/469)

Removes `all-contributors` badge, since it isn't used, and is out of date.