### PR TITLE
[FEAT]: optimised word filter(alex)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -40,9 +40,9 @@ export default {
         'You can assign this role to yourself to subscribe to get open-source reminders and if you like contributing to open-source software',
     },
   },
-  defaultEmbed: () => {
+  defaultEmbed: (color = '#0099ff') => {
     return new MessageEmbed()
-      .setColor('#0099ff')
+      .setColor(color)
       .setTimestamp()
       .setFooter(
         'Our bot is Open Source, you can find it here https://github.com/EddieJaoudeCommunity/EddieBot'

--- a/src/words.ts
+++ b/src/words.ts
@@ -16,13 +16,12 @@ export const words = async (message: Message) => {
   if (message.author.bot) {
     return;
   }
-  // Regex to remove puntuation from text
-  const textAfterRemovingPunctuation = message.content
-    .replace(/[.,/#!$%&*;:{}<>=\-_'"~()]/g, ' ')
-    .replace(/\s{2,}/g, ' ');
-  const match = alex.markdown(textAfterRemovingPunctuation, ALEX as alex.Config)
-    .messages;
 
+  // Regex to remove puntuation from text
+  const match = alex.markdown(
+    stripSpecialCharacters(message.content),
+    ALEX as alex.Config
+  ).messages;
   if (match.length) {
     const embed = defaultEmbed()
       .setTitle(`You used the word "${match[0].actual}"`)
@@ -40,3 +39,10 @@ export const words = async (message: Message) => {
 
   return;
 };
+
+// Utility function for removing special characters
+function stripSpecialCharacters(str: string) {
+  // match characters . , and replace with ' '
+  // regex to replace special symbols with ' '
+  return str.replace(/[.,]/g, ' ').replace(/[.,/#!$%&*;:{}<>=\-_'"~()]/, ' ');
+}

--- a/src/words.ts
+++ b/src/words.ts
@@ -16,8 +16,12 @@ export const words = async (message: Message) => {
   if (message.author.bot) {
     return;
   }
-
-  const match = alex.markdown(message.content, ALEX as alex.Config).messages;
+  // Regex to remove puntuation from text
+  const textAfterRemovingPunctuation = message.content
+    .replace(/[.,/#!$%&*;:{}=\-_'"~()]/g, ' ')
+    .replace(/\s{2,}/g, ' ');
+  const match = alex.markdown(textAfterRemovingPunctuation, ALEX as alex.Config)
+    .messages;
 
   if (match.length) {
     const embed = defaultEmbed()

--- a/src/words.ts
+++ b/src/words.ts
@@ -18,7 +18,7 @@ export const words = async (message: Message) => {
   }
   // Regex to remove puntuation from text
   const textAfterRemovingPunctuation = message.content
-    .replace(/[.,/#!$%&*;:{}=\-_'"~()]/g, ' ')
+    .replace(/[.,/#!$%&*;:{}<>=\-_'"~()]/g, ' ')
     .replace(/\s{2,}/g, ' ');
   const match = alex.markdown(textAfterRemovingPunctuation, ALEX as alex.Config)
     .messages;

--- a/src/words.ts
+++ b/src/words.ts
@@ -42,7 +42,8 @@ export const words = async (message: Message) => {
 
 // Utility function for removing special characters
 function stripSpecialCharacters(str: string) {
-  // match characters . , and replace with ' '
-  // regex to replace special symbols with ' '
-  return str.replace(/[.,]/g, ' ').replace(/[.,/#!$%&*;:{}<>=\-_'"~()]/, ' ');
+  // match special symbols and replace with ' '
+  str = str.replace(/[.,/#!$%&*;:{}=\-_'"~()]/g, ' ');
+  // match double whitespace with single space for cleaner string
+  return str.replace(/\s{2,}/g, ' ');
 }


### PR DESCRIPTION
## Category: **Feature request**

## What does this PR introduce?:

This PR adds a regex to replace the punctuation in `message.content` fetched from messages, to get normal text strings.
Regex used:
`message.content.replace(/[.,/#!$%&*;:{}=\-_'"~()]/g, ' ').replace(/\s{2,}/g, ' ');`
Is there any way to make this better or to include more flags, to ensure that this reduces as much loopholes in Alex, as possible? Any suggestions would be great :)

| **Before this PR** | **After this PR**  |
| ------------------ | ----------------- |
| easy = `gets flagged`| easy = `gets flagged`| 
| , easy, = `not flagged`| , easy, = `gets flagged`|
| `easy` = `not flagged`| `easy` = `not flagged`|
| -easy- = `not flagged`| -easy- = `gets flagged`|
| "easy" = `not flagged`| "easy" = `gets flagged`|

*_the word `easy` has been used as a convenient example here_

## ISSUE- #337

## Screenshots: 
| **Before this PR** | **After this PR**  |
| ------------------ | ----------------- |
| ![before](https://user-images.githubusercontent.com/62864373/102022974-613f2a00-3db0-11eb-8e2c-2c7cacda64c3.png) | ![after](https://user-images.githubusercontent.com/62864373/102022930-f5f55800-3daf-11eb-85a8-0811705b2876.png)|
| ![before](https://user-images.githubusercontent.com/62864373/102023022-ad8a6a00-3db0-11eb-8337-60e7e5c39922.png) | ![Screenshot 2020-12-14 at 2 05 09 AM](https://user-images.githubusercontent.com/62864373/102023048-d3b00a00-3db0-11eb-8c43-2e3d62c3cc5d.png) |


## Additional Context:
(*I had to mishmash this from: [web.mit.edu](http://web.mit.edu/gnu/doc/html/regex_3.html) and [computerhope.com page](https://www.computerhope.com/unix/regex-quickref.htm), after my text processing implementation didn't work properly and involved using unnecessary variables)
(Also, does the _tabularised_ before-after look weird, or does it look fine and readable?)
Issue:  #337 