### PR TITLE
[fix]: fixed multiple reminders for same word

### DIFF
--- a/src/words.ts
+++ b/src/words.ts
@@ -19,7 +19,7 @@ export const words = async (message: Message) => {
 
   // Modify text by removing redundancy and special characters
   const messageText = [
-    ...new Set(stripSpecialCharacters(message.content)),
+    ...new Set(stripSpecialCharacters(message.content).split(' ')),
   ].join(' ');
   const match = alex.markdown(messageText, ALEX as alex.Config).messages;
   if (match.length) {
@@ -45,5 +45,5 @@ function stripSpecialCharacters(str: string) {
   // match special symbols and replace with ' '
   str = str.replace(/[.,/#!$%&*;:{}=\-_'"~()]/g, ' ');
   // match double whitespace with single space for cleaner string
-  return str.replace(/\s{2,}/g, ' ').split(' ');
+  return str.replace(/\s{2,}/g, ' ');
 }

--- a/src/words.ts
+++ b/src/words.ts
@@ -17,11 +17,11 @@ export const words = async (message: Message) => {
     return;
   }
 
-  // Regex to remove puntuation from text
-  const match = alex.markdown(
-    stripSpecialCharacters(message.content),
-    ALEX as alex.Config
-  ).messages;
+  // Modify text by removing redundancy and special characters
+  const messageText = [
+    ...new Set(stripSpecialCharacters(message.content)),
+  ].join(' ');
+  const match = alex.markdown(messageText, ALEX as alex.Config).messages;
   if (match.length) {
     const embed = defaultEmbed(config.COLORS.alerts)
       .setTitle(`You used the word "${match[0].actual}"`)
@@ -45,5 +45,5 @@ function stripSpecialCharacters(str: string) {
   // match special symbols and replace with ' '
   str = str.replace(/[.,/#!$%&*;:{}=\-_'"~()]/g, ' ');
   // match double whitespace with single space for cleaner string
-  return str.replace(/\s{2,}/g, ' ');
+  return str.replace(/\s{2,}/g, ' ').split(' ');
 }


### PR DESCRIPTION
## Description: 
This PR introduces small changes to `src/words.ts`, to prevent Alex from returning multiple reminders(flags) for the same word repeated a no. of times.

## Context:
![before](https://user-images.githubusercontent.com/61582763/100863157-238df780-34ba-11eb-851d-e793ff3d5949.png)

## The Fix:
The message string(after the special characters are removed), is converted into an array, which is converted to a set, and joined back with spaces in between as a string.
![code exerpt](https://media.discordapp.net/attachments/699880048504733747/789144821998551070/Screenshot_2020-12-17_at_8.28.31_PM.png)

## Relevant Screenshot:
**AFTER**
![after](https://cdn.discordapp.com/attachments/699880048504733747/789144821998551070/Screenshot_2020-12-17_at_8.28.31_PM.png)
Issue: closes #357 