### PR TITLE
fix: allow the use of Mexican

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -107,6 +107,7 @@ export default {
       'basically',
       'long-time-no-see',
       'moan',
+      'latino',
     ],
   },
 };


### PR DESCRIPTION
Allows the use of `Mexican` instead of recommending `Latinx`.

Ref: [Discord conversation](https://discord.com/channels/699608417039286293/717736706555641986/802637940211580990)

**Note:** This will also stop flagging `Latino` and `Latina` - take into consideration before merging.

Signed-off-by: nhcarrigan <nhcarrigan@gmail.com>