### PR TITLE
fix: allow `postman`

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -108,6 +108,7 @@ export default {
       'long-time-no-see',
       'moan',
       'latino',
+      'postman-postwoman',
     ],
   },
 };


### PR DESCRIPTION
Allows `postman` (also, `postwoman`, unfortunately) to stop flagging
our use of the software by the same name.

Ref: https://discord.com/channels/699608417039286293/699609489699110943/803734701382565918

Signed-off-by: nhcarrigan <nhcarrigan@gmail.com>